### PR TITLE
Add interface for data service to login and signup pages

### DIFF
--- a/src/dataService.js
+++ b/src/dataService.js
@@ -11,9 +11,20 @@ class DataService {
             userName: 'testo',
             email: 'testo@testo.com',
             password: 'testotesto',
-            confirmPassword: 'testotesto',
-            chef: 'on'
+            confirmPassword: 'testotesto'
         })
+    }
+    signup(msg) {
+        return URL.post(`/signup`, msg)
+    }
+    checkLogin(msg) {
+        return URL.get(`/login`, msg)
+    }
+    login(msg) {
+        return URL.post(`/login`, msg)
+    }
+    logout(msg) {
+        return URL.get(`/logout`, msg)
     }
 }
 

--- a/src/pages/Create.js
+++ b/src/pages/Create.js
@@ -1,5 +1,4 @@
 import React, {useState, useEffect} from "react";
-import DataService from "../dataService";
 
 const Create = () => {
 

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,8 +1,18 @@
-import React, {useState} from 'react'
+import React, {useState, useEffect} from 'react'
 import { Typography, Card, CardContent, Grid, TextField, Button } from '@mui/material'
+import DataService from "../dataService";
 
 const Login = () => {
-      const defaultValues = {
+
+    useEffect(() => {
+        const getStatus = async () => {
+            const status = await DataService.checkLogin()
+            console.log(status);
+        }
+        getStatus()
+    }, [])
+    
+    const defaultValues = {
       email: "",
       password: "",
     };
@@ -19,13 +29,14 @@ const Login = () => {
 
     const handleSubmit = e => {
         e.preventDefault();
+        DataService.login(formValues);
         console.log(formValues);
     }
 
     return (
       <Card style={{maxWidth:600, margin:'0 auto', padding: '20px 5px'}}>
           <CardContent>
-              <Typography gutterBottom variant='h5'>Sign Up</Typography>
+              <Typography gutterBottom variant='h5'>Log In</Typography>
               <form onSubmit={handleSubmit}>
                   <Grid container spacing={1}>
                       <Grid xs={12} sm={6} item>

--- a/src/pages/Signup.js
+++ b/src/pages/Signup.js
@@ -1,13 +1,14 @@
 import React, {useState} from 'react'
 import { Typography, Card, CardContent, Grid, TextField, Button } from '@mui/material'
+import DataService from "../dataService";
 
 const Signup = () => {
 
     const defaultValues = {
-      username: "",
+      userName: "",
       email: "",
       password: "",
-      passwordConfirm: "",
+      confirmPassword: "",
     };
 
     const [formValues, setFormValues] = useState(defaultValues);
@@ -22,6 +23,7 @@ const Signup = () => {
 
     const handleSubmit = e => {
         e.preventDefault();
+        DataService.signup(formValues);
         console.log(formValues);
     }
 
@@ -32,7 +34,7 @@ const Signup = () => {
               <form onSubmit={handleSubmit}>
                   <Grid container spacing={1}>
                       <Grid xs={12} sm={6} item>
-                          <TextField name='username' value={formValues.username} onChange={handleInputChange} label='Username' placeholder='Enter Username' variant='outlined' fullWidth required></TextField>
+                          <TextField name='userName' value={formValues.userName} onChange={handleInputChange} label='Username' placeholder='Enter Username' variant='outlined' fullWidth required></TextField>
                       </Grid>
                       <Grid xs={12} sm={6} item>
                           <TextField name='email' value={formValues.email} onChange={handleInputChange} type='email' label='Email' placeholder='Enter Email' variant='outlined' fullWidth required></TextField>
@@ -41,7 +43,7 @@ const Signup = () => {
                           <TextField name='password' value={formValues.password} onChange={handleInputChange} label='Password' placeholder='Enter Password' variant='outlined' fullWidth required></TextField>
                       </Grid>
                       <Grid xs={12} sm={6} item>
-                          <TextField name='passwordConfirm' value={formValues.passwordConfirm} onChange={handleInputChange} label='Confirm Password' placeholder='Confirm Password' variant='outlined' fullWidth required></TextField>
+                          <TextField name='confirmPassword' value={formValues.confirmPassword} onChange={handleInputChange} label='Confirm Password' placeholder='Confirm Password' variant='outlined' fullWidth required></TextField>
                       </Grid>
                       <Grid xs={12}item>
                           <Button type='submit' variant='contained' color='primary' fullWidth>Submit</Button>


### PR DESCRIPTION
# Description

Built functionality into login and signup pages that accepts form data, bundles it into a JSON message, and passes it to the data service.

Fixes Issue 6 - Hook up signup/login pages to backend

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings